### PR TITLE
Created issue templates for bug and crash reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: A bug within Chromium Legacy
+title: "[BUG]"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. macOS X Lion]
+ - Build [e.g. 967793]
+
+**Logs**
+If logs were provided please add them here with the code tag or attach them to the issue
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/crash-report.md
+++ b/.github/ISSUE_TEMPLATE/crash-report.md
@@ -1,0 +1,30 @@
+---
+name: Crash report
+about: A problem that causes Chromium Legacy to crash
+title: "[CRASH]"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. macOS X Lion]
+ - Build [e.g. 967793]
+
+**Logs**
+If logs were provided please add them here with the code tag or attach them to the issue
+
+Add any other context about the problem here.


### PR DESCRIPTION
There's currently no issue templates in the repository and I feel like the lack of it might intimidate people and prevent them from posting new issues. Besides, having the template can always be useful and forgetting about needed information won't be a problem. I created two very basic templates for a normal bug report and a crash report.